### PR TITLE
Fix hot key bug

### DIFF
--- a/js/shortcuts.js
+++ b/js/shortcuts.js
@@ -302,6 +302,18 @@ define([ "jquery", "mousetrap", "controlbar", "i18n", "topsites", "message" ], f
         });
     }
 
+    //overwriting Mousetrap stopCallback function
+    Mousetrap.prototype.stopCallback=function(e, element, combo) {
+
+        // if the element has the class "mousetrap" then no need to stop
+        if ((' ' + element.className + ' ').indexOf(' mousetrap ') > -1 || combo == 'esc') {
+            return false;
+        }
+
+        // stop for input, select, and textarea
+        return element.tagName == 'INPUT' || element.tagName == 'SELECT' || element.tagName == 'TEXTAREA' || (element.contentEditable && element.contentEditable == 'true');
+    }
+
     return {
         Init: function () {
             listenCurrentTab();


### PR DESCRIPTION
简Tab开启书签栏后的搜索框因为mousetrap默认情况下在输入或选择范围内无法触发键盘事件，导致ESC无法关闭使用q快捷键调出的搜索框。

我依照mousetrap官方文档，重写了stopCallback函数，使得在输入区域可以对ESC按键放行。